### PR TITLE
feat: add overrides `num-columns` and `group-heading-level`

### DIFF
--- a/themes/default.typ
+++ b/themes/default.typ
@@ -718,6 +718,8 @@
   entries,
   groups,
   show-all: false,
+  group-heading-level: none,
+  num-columns: 1,
   disable-back-references: false,
   user-print-reference: default-print-reference,
   user-group-break: default-group-break,
@@ -727,10 +729,13 @@
   user-print-back-references: default-print-back-references,
 ) = {
   let body = []
-  let previous-headings = query(selector(heading).before(here()))
-  let group-heading-level = 1
-  if previous-headings.len() != 0 {
-    group-heading-level = previous-headings.last().level
+  if group-heading-level == none {
+    let previous-headings = query(selector(heading).before(here()))
+    group-heading-level = if previous-headings.len() != 0 {
+      previous-headings.last().level
+    } else {
+      1
+    }
   }
   for group in groups.sorted() {
     let group-entries = entries.filter(x => x.at("group") == group)
@@ -761,7 +766,7 @@
     body += user-group-break()
   }
 
-  return body
+  return columns(num-columns, body)
 }
 
 //  __update_glossary(entries) -> none
@@ -814,6 +819,8 @@
 #let print-glossary(
   entry-list,
   show-all: false,
+  group-heading-level: none,
+  num-columns: 1,
   disable-back-references: false,
   user-print-glossary: default-print-glossary,
   user-print-reference: default-print-reference,
@@ -839,6 +846,8 @@
       entries,
       groups,
       show-all: show-all,
+      group-heading-level: group-heading-level,
+      num-columns: num-columns,
       disable-back-references: disable-back-references,
       user-print-reference: user-print-reference,
       user-group-break: user-group-break,


### PR DESCRIPTION
Before this change, `group-heading-level` defaulted to reusing the last heading level found in the document. This is unlikely to always work for users. This new parameter allows users to override the default.

Additionally, to give users some ability to style the output without needing to override `user-print-glossary`, the new `num-columns` parameter gives users the ability to control the number of columns groups are printed in.