### PR TITLE
flake: input master is no longer needed

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,21 +3,18 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    master.url = "github:nixos/nixpkgs/master";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs = {
     self,
     nixpkgs,
-    master,
     flake-utils,
   }:
     flake-utils.lib.eachDefaultSystem
     (
       system: let
         pkgs = nixpkgs.legacyPackages.${system};
-        masterPkgs = master.legacyPackages.${system};
       in {
         devShell = pkgs.mkShell {
           buildInputs = [
@@ -25,8 +22,7 @@
             pkgs.just
             pkgs.zathura
             pkgs.typstyle
-
-            masterPkgs.tbump
+            pkgs.tbump
           ];
         };
       }


### PR DESCRIPTION
tbump is now available in unsable, I removed the master input 

https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=tbump