### PR TITLE
Styling glossarium references only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,4 +192,5 @@ It is also possible to apply styling specifically to the glossarium references, 
   }
 }
 ```
-By adding `else if` clauses for different functions and kinds, each type of reference can be given a different style. 
+(Thanks to flokl for the [solution](https://forum.typst.app/t/how-do-you-apply-a-style-to-glossarium-references-that-is-different-to-other-reference-types/2089/2?u=ogre) on the Typst forums).
+By adding `else if` clauses for different functions and kinds, each type of reference can be given a different style.

--- a/README.md
+++ b/README.md
@@ -178,3 +178,18 @@ I recommend setting a show rule for the links to that your readers understand th
 #show link: set text(fill: blue.darken(60%))
 // links are now blue !
 ```
+
+It is also possible to apply styling specifically to the glossarium references, like in this example:
+```typ
+#show ref: it => {
+  let el = it.element
+  if el != none and el.func() == figure and el.kind == "glossarium_entry" {
+    // Make the glossarium entry references dark blue
+    text(fill: blue.darken(60%))
+  } else {
+    // Other references as usual.
+    it
+  }
+}
+```
+By adding `else if` clauses for different functions and kinds, each type of reference can be given a different style. 


### PR DESCRIPTION
Added an example to the README, which allows for styling only the glossarium references, while leaving the style of other references alone.