### PR TITLE
Fix non-bold entries

### DIFF
--- a/themes/default.typ
+++ b/themes/default.typ
@@ -684,7 +684,7 @@
 // The title of the entry
 #let default-print-title(entry) = {
   let caption = []
-  let txt = text.with(weight: 600)
+  let txt(it) = strong(text.with(weight: 300)(it))
 
   if has-long(entry) and has-short(entry) {
     caption += txt(emph(entry.short) + [ -- ] + entry.long)

--- a/themes/default.typ
+++ b/themes/default.typ
@@ -684,7 +684,7 @@
 // The title of the entry
 #let default-print-title(entry) = {
   let caption = []
-  let txt(it) = strong(text.with(weight: 300)(it))
+  let txt = strong.with(delta: 200)
 
   if has-long(entry) and has-short(entry) {
     caption += txt(emph(entry.short) + [ -- ] + entry.long)


### PR DESCRIPTION
Currently, if I input certain kinds of content in the entry field, the displayed entry will not be bold. For example, if I have:

```
#import "@preview/glossarium:0.5.3": make-glossary, register-glossary, print-glossary, gls

#show: make-glossary

#let main-glossary = (
  (
    key: "potato",
    short: "potato"
  ),
)

#let symbols-glossary = (
  (
    key: "mu_0",
    short: $mu_0$,
    description: "Vacuum magnetic permeability"
  ),
  (
    key: "A",
    short: $A$,
    description: "A letter"
  ),
  (
    key: "ZRL",
    short: $Z_"RL"$,
    description: "An impedance"
  ),
)

#register-glossary(main-glossary)
#register-glossary(symbols-glossary)

#gls("potato") #gls("mu_0") #gls("A") #gls("ZRL")

= Glossary
#print-glossary(main-glossary)

== Symbols
#print-glossary(symbols-glossary)
```

The output will be as follows:

![Screenshot_20250220_001201](https://github.com/user-attachments/assets/ea8da023-1fa2-462f-8c4c-2ccea0139e62)

The issue is that the math-formatted entries don't show up as bold, as glossary entries normally do. This pull request fixes this behavior, the output becoming this:

![Screenshot_20250220_001235](https://github.com/user-attachments/assets/a31c45cf-b5f0-4e48-afac-0457ce75a167)

Note: while these examples are all replicable with functions such as `sym` and `sub`, I have observed this to happen with some specific formatting like that of fractions and simultaneous super/sub-scripts.