### PR TITLE
Fix 'has-<attribute>' checks

### DIFF
--- a/themes/default.typ
+++ b/themes/default.typ
@@ -206,8 +206,8 @@
 }
 
 #let __has_attribute(entry, key) = {
-  let attr = entry.at(key, default: "")
-  return attr != "" and attr != []
+  let attr = entry.at(key, default: none)
+  return attr != none and attr != []
 }
 #let has-short(entry) = __has_attribute(entry, "short")
 #let has-long(entry) = __has_attribute(entry, "long")


### PR DESCRIPTION
Hotfix for the current 0.5.4 release candidate. I hope you can merge it before the package update. Basically, on https://github.com/typst-community/glossarium/commit/0c9ce1eda3fd70dbf715344d5000451b779377f0 you changed the defaults of attributes such as `plural` to `none`, while keeping the check for then as a check against `""`. This led glossarium to always assume those attributes were present, leading to unintended behavior like a dash always being appended to the term even if it didn't have a plural form.