### PR TITLE
Fix: Whitespace after label and in-between

### DIFF
--- a/themes/default.typ
+++ b/themes/default.typ
@@ -229,13 +229,9 @@
 //
 // # Returns
 // The link and the entry label
-#let __link_and_label(key, text, prefix: none, suffix: none, update: true) = [
-  #if update { __update_count(key) }
-  #prefix
-  #link(label(key), text)
-  #suffix
-  #label(__glossary_label_prefix + key)
-]
+#let __link_and_label(key, text, prefix: none, suffix: none, update: true) = [#if update {
+    __update_count(key)
+  }#prefix#link(label(key), text)#suffix#label(__glossary_label_prefix + key)]
 
 // gls(key, suffix: none, long: none, display: none) -> contextual content
 // Reference to term


### PR DESCRIPTION
Dispite ugly syntax here (because you can't attach a label to content in code context), only way to get rid of in-between or following whitespaces - this could have impacted when wrapping all "link"-elements with "underline" (to show they are clickable). The underline will span over the whitespace then.