### PR TITLE
Remove extra spaces in __link_and_label

### DIFF
--- a/themes/default.typ
+++ b/themes/default.typ
@@ -231,7 +231,7 @@
 // The link and the entry label
 #let __link_and_label(key, text, prefix: none, suffix: none, update: true) = {
   if update { __update_count(key) }
-  return prefix + link(label(key), text) + suffix + label(__glossary_label_prefix + key)
+  [#prefix#link(label(key), text)#suffix#label(__glossary_label_prefix + key)]
 }
 
 // gls(key, suffix: none, long: none, display: none) -> contextual content

--- a/themes/default.typ
+++ b/themes/default.typ
@@ -229,13 +229,10 @@
 //
 // # Returns
 // The link and the entry label
-#let __link_and_label(key, text, prefix: none, suffix: none, update: true) = [
-  #if update { __update_count(key) }
-  #prefix
-  #link(label(key), text)
-  #suffix
-  #label(__glossary_label_prefix + key)
-]
+#let __link_and_label(key, text, prefix: none, suffix: none, update: true) = {
+  if update { __update_count(key) }
+  return prefix + link(label(key), text) + suffix + label(__glossary_label_prefix + key)
+}
 
 // gls(key, suffix: none, long: none, display: none) -> contextual content
 // Reference to term


### PR DESCRIPTION
When trying to append a symbol (e.g. punctuation, dash, ...) before or after the glossarium reference, an extra space is inserted in between:
```typst
#import "@preview/glossarium:0.5.4": make-glossary, register-glossary, print-glossary, gls, glspl
#show: make-glossary
#let entry-list = (
  (
    key: "kuleuven",
    short: "KU Leuven",
    long: "Katholieke Universiteit Leuven",
    description: "A university in Belgium.",
  ),
  // Add more terms
)
#register-glossary(entry-list)

Mention @kuleuven once so the next mentions can use the short form.

Some sentence with @kuleuven, but there is a space in front of the comma.

The same happens when it appears at the end of the sentence: @kuleuven.

#gls("kuleuven")-based startups are out of luck as well.

The Haasrode-#gls("kuleuven")-cooperation.

#print-glossary(
 entry-list
)

```

Will create this output:
![image](https://github.com/user-attachments/assets/121c07b6-7df4-4698-84b3-b6a044d33fc2)

This is because the indentation in each new line in `__link_and_label` is formatted as a space.

I don't know of any way in current `typst` to ignore the indentation, so I propose to remove it outright and merge all content lines into a single one.

With the proposed change, there is no more spacing:
![image](https://github.com/user-attachments/assets/41ab139a-87ca-4cfb-affd-d14c64c23748)

