### PR TITLE
Check for null string attributes

### DIFF
--- a/themes/default.typ
+++ b/themes/default.typ
@@ -207,7 +207,7 @@
 
 #let __has_attribute(entry, key) = {
   let attr = entry.at(key, default: none)
-  return attr != none and attr != []
+  return attr != none and attr != "" and attr != []
 }
 #let has-short(entry) = __has_attribute(entry, "short")
 #let has-long(entry) = __has_attribute(entry, "long")


### PR DESCRIPTION
Very minor PR to fix an oversight I made in https://github.com/typst-community/glossarium/pull/114. Back then I replaced the check against `""` with one against `none`, since `none` was the new default. However, there was also a check in place for if the user wrote `[]`. To stay consistent with that behavior, I'd say we could check for all three.