### PR TITLE
chore(CI.yml): Update workflow dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,9 +1,8 @@
 name: Build example
 
-
 on:
   push:
-    branches: 
+    branches:
       - master
   pull_request:
     types: [opened, synchronize, reopened]
@@ -12,21 +11,18 @@ jobs:
   build-example:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup typst  
-        uses: yusancky/setup-typst@v2
-        id: setup-typst
-        with:
-          version: 'latest'
+      - name: Setup typst
+        uses: typst-community/setup-typst@v4
       - name: Setup Just
-        uses: extractions/setup-just@v2
+        uses: extractions/setup-just@v3
       - name: Set up Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: typst version
         run: typst --version
       - name: Compile
         run: just build-examples
-      - name: Upload example PDF 
-        uses: actions/upload-artifact@v3
+      - name: Upload example PDF
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}_PDF_EXAMPLES
           path: examples/*
@@ -34,21 +30,18 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup typst  
-        uses: yusancky/setup-typst@v2
-        id: setup-typst
-        with:
-          version: 'latest'
+      - name: Setup typst
+        uses: typst-community/setup-typst@v4
       - name: Setup Just
-        uses: extractions/setup-just@v2
+        uses: extractions/setup-just@v3
       - name: Set up Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: typst version
         run: typst --version
       - name: Compile
         run: just test
-      - name: Upload example PDF 
-        uses: actions/upload-artifact@v3
+      - name: Upload example PDF
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}_PDF_TESTS
           path: tests/*


### PR DESCRIPTION
- `yusancky/setup-typst@v2` → `typst-community/setup-typst@v4` https://github.com/yusancky/setup-typst/blob/main/announcement.md
- `extractions/setup-just@v2` → `extractions/setup-just@v3` https://github.com/extractions/setup-just/pull/19
- `actions/checkout@v3` → `actions/checkout@v4` https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
- `actions/upload-artifact@v3` → `actions/upload-artifact@v4` https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/