### PR TITLE
Export Gls and Glspl commands

### DIFF
--- a/glossarium.typ
+++ b/glossarium.typ
@@ -8,4 +8,4 @@
 // SOFTWARE.
 
 // @typstyle off
-#import "themes/default.typ": gls, agls, glspl, make-glossary, register-glossary, print-glossary, gls-key, gls-short, gls-artshort, gls-plural, gls-long, gls-artlong, gls-longplural, gls-description, gls-group, get-entry-back-references, count-refs, count-all-refs, there-are-refs
+#import "themes/default.typ": gls, agls, glspl, make-glossary, register-glossary, print-glossary, gls-key, gls-short, gls-artshort, gls-plural, gls-long, gls-artlong, gls-longplural, gls-description, gls-group, get-entry-back-references, count-refs, count-all-refs, there-are-refs, Gls, Glspl

--- a/themes/default.typ
+++ b/themes/default.typ
@@ -479,7 +479,7 @@
   return __link_and_label(entry.key, text, href: link, update: update)
 }
 
-// gls(key, suffix: none, long: false, display: none) -> contextual content
+// Gls(key, suffix: none, long: false, display: none) -> contextual content
 // Reference to term, capitalized
 #let Gls(key, suffix: none, long: false, display: none, link: true, update: true) = gls(
   key,
@@ -606,7 +606,7 @@
   return __link_and_label(entry.key, text, href: link, update: update)
 }
 
-// glspl(key, long: false) -> content
+// Glspl(key, long: false) -> content
 // Reference to term with plural form, capitalized
 #let Glspl(key, long: false, link: true, update: true) = glspl(
   key,


### PR DESCRIPTION
Also changed the capitalization of the docstring of the two commands to match the command.

Closes https://github.com/typst-community/glossarium/issues/132