### PR TITLE
Add module `internal` to exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ glossarium.pdf
 /.gtm/
 out/
 diff/
+.direnv/
+.DS_Store

--- a/advanced-docs/main.typ
+++ b/advanced-docs/main.typ
@@ -95,6 +95,12 @@ any suggestions or need help, please open an issue on the #link(
   "https://github.com/typst-community/glossarium",
 )[GitHub repository].
 
+Internal functions (for example all `default-print-*` functions showed in the following) are exported from a module `internal`:
+
+```typ
+#import "@preview/glossarium:x.x.x": internal
+```
+
 There are effectively two requirements for a user to use `glossarium`:
 + Write a #typc("show: make-glossary") rule to transform all #typc("@key") and
   #typc("@key:pl") into #typc("#gls(key)") or

--- a/glossarium.typ
+++ b/glossarium.typ
@@ -7,6 +7,39 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#import "themes/default.typ" as internal: (
+  glossarium_version,
+  ATTRIBUTES,
+  default-shorthands,
+  default-capitalize,
+  there-are-refs,
+  is-first,
+  has-short,
+  has-long,
+  has-artshort,
+  has-artlong,
+  has-plural,
+  has-longplural,
+  has-description,
+  has-group,
+  has-sort,
+  has-styles,
+  has-custom,
+  get-attribute,
+  is-upper,
+  default-plural,
+  refrule,
+  default-print-back-references,
+  default-print-description,
+  default-group-break,
+  default-print-gloss,
+  default-print-glossary,
+  default-print-group-heading,
+  default-print-reference,
+  default-print-title,
+  default-group-break,
+)
+
 #import "themes/default.typ": (
   gls,
   agls,


### PR DESCRIPTION
This PR adds a module `internal` to the list of exports. It contains all non-private functions (no trailing `_`) that are not exported in the top level module.

This gives packages users to style glossarium more easily, because, for example, default implementations from glossarium can still be used.

closes #193 